### PR TITLE
[iOS] 레이블, 마일스톤 생성 공통뷰 구현 완료

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		970CAD54254A73B60076691E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 970CAD53254A73B60076691E /* Assets.xcassets */; };
 		970CAD57254A73B60076691E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 970CAD55254A73B60076691E /* LaunchScreen.storyboard */; };
 		970CAD62254A73B60076691E /* IssueTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970CAD61254A73B60076691E /* IssueTrackerTests.swift */; };
+		97664C66254A83CB005B98A7 /* CreationFormView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 97664C65254A83CB005B98A7 /* CreationFormView.xib */; };
+		97664C68254A91CA005B98A7 /* CreationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97664C67254A91CA005B98A7 /* CreationFormView.swift */; };
 		AD03E99288CFBAF7CD0C632F /* Pods_IssueTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28DDFD2F384F60488622CBA3 /* Pods_IssueTrackerTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -42,6 +44,8 @@
 		970CAD5D254A73B60076691E /* IssueTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IssueTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		970CAD61254A73B60076691E /* IssueTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTrackerTests.swift; sourceTree = "<group>"; };
 		970CAD63254A73B60076691E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		97664C65254A83CB005B98A7 /* CreationFormView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreationFormView.xib; sourceTree = "<group>"; };
+		97664C67254A91CA005B98A7 /* CreationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFormView.swift; sourceTree = "<group>"; };
 		BEE1F894F9C40EEFD4B9E644 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
 		CA535DA5AF5BF90B4980A30E /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		D7F620D4C0E1073F1AD8C102 /* Pods_IssueTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,6 +95,7 @@
 		970CAD49254A73B50076691E /* IssueTracker */ = {
 			isa = PBXGroup;
 			children = (
+				97664C63254A81C4005B98A7 /* View */,
 				970CAD4A254A73B50076691E /* AppDelegate.swift */,
 				970CAD4C254A73B50076691E /* SceneDelegate.swift */,
 				970CAD4E254A73B50076691E /* ViewController.swift */,
@@ -125,6 +130,23 @@
 				970CAD55254A73B60076691E /* LaunchScreen.storyboard */,
 			);
 			path = Storyboards;
+			sourceTree = "<group>";
+		};
+		97664C63254A81C4005B98A7 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				97664C64254A81D2005B98A7 /* CreationView */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		97664C64254A81D2005B98A7 /* CreationView */ = {
+			isa = PBXGroup;
+			children = (
+				97664C65254A83CB005B98A7 /* CreationFormView.xib */,
+				97664C67254A91CA005B98A7 /* CreationFormView.swift */,
+			);
+			path = CreationView;
 			sourceTree = "<group>";
 		};
 		CF482D6A08BAC56ABDC949F6 /* Pods */ = {
@@ -232,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970CAD57254A73B60076691E /* LaunchScreen.storyboard in Resources */,
+				97664C66254A83CB005B98A7 /* CreationFormView.xib in Resources */,
 				970CAD54254A73B60076691E /* Assets.xcassets in Resources */,
 				970CAD52254A73B50076691E /* Main.storyboard in Resources */,
 			);
@@ -317,6 +340,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				970CAD4F254A73B50076691E /* ViewController.swift in Sources */,
+				97664C68254A91CA005B98A7 /* CreationFormView.swift in Sources */,
 				970CAD4B254A73B50076691E /* AppDelegate.swift in Sources */,
 				970CAD4D254A73B50076691E /* SceneDelegate.swift in Sources */,
 			);

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		970CAD54254A73B60076691E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 970CAD53254A73B60076691E /* Assets.xcassets */; };
 		970CAD57254A73B60076691E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 970CAD55254A73B60076691E /* LaunchScreen.storyboard */; };
 		970CAD62254A73B60076691E /* IssueTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970CAD61254A73B60076691E /* IssueTrackerTests.swift */; };
+		9763DFF0254B361200BCBD6A /* CreationFormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9763DFEF254B361200BCBD6A /* CreationFormType.swift */; };
 		97664C66254A83CB005B98A7 /* CreationFormView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 97664C65254A83CB005B98A7 /* CreationFormView.xib */; };
 		97664C68254A91CA005B98A7 /* CreationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97664C67254A91CA005B98A7 /* CreationFormView.swift */; };
 		AD03E99288CFBAF7CD0C632F /* Pods_IssueTrackerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28DDFD2F384F60488622CBA3 /* Pods_IssueTrackerTests.framework */; };
@@ -44,6 +45,7 @@
 		970CAD5D254A73B60076691E /* IssueTrackerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IssueTrackerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		970CAD61254A73B60076691E /* IssueTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTrackerTests.swift; sourceTree = "<group>"; };
 		970CAD63254A73B60076691E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9763DFEF254B361200BCBD6A /* CreationFormType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFormType.swift; sourceTree = "<group>"; };
 		97664C65254A83CB005B98A7 /* CreationFormView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreationFormView.xib; sourceTree = "<group>"; };
 		97664C67254A91CA005B98A7 /* CreationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFormView.swift; sourceTree = "<group>"; };
 		BEE1F894F9C40EEFD4B9E644 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 			children = (
 				97664C65254A83CB005B98A7 /* CreationFormView.xib */,
 				97664C67254A91CA005B98A7 /* CreationFormView.swift */,
+				9763DFEF254B361200BCBD6A /* CreationFormType.swift */,
 			);
 			path = CreationView;
 			sourceTree = "<group>";
@@ -339,6 +342,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9763DFF0254B361200BCBD6A /* CreationFormType.swift in Sources */,
 				970CAD4F254A73B50076691E /* ViewController.swift in Sources */,
 				97664C68254A91CA005B98A7 /* CreationFormView.swift in Sources */,
 				970CAD4B254A73B50076691E /* AppDelegate.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormType.swift
+++ b/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormType.swift
@@ -1,0 +1,27 @@
+//
+//  CreationFormType.swift
+//  IssueTracker
+//
+//  Created by 김근수 on 2020/10/30.
+//  Copyright © 2020 김근수. All rights reserved.
+//
+
+import Foundation
+
+enum CreationFormType {
+    case label
+    case milestone
+}
+
+extension CreationFormType {
+    
+    var formTitles: [String] {
+        switch self {
+        case .label:
+            return ["제목", "설명", "색상"]
+        case .milestone:
+            return ["제목", "완료날짜", "설명"]
+        }
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.swift
@@ -1,0 +1,119 @@
+//
+//  CreationFormView.swift
+//  IssueTracker
+//
+//  Created by 김근수 on 2020/10/29.
+//  Copyright © 2020 김근수. All rights reserved.
+//
+
+import UIKit
+
+protocol CreationFormViewDelegate: class {
+    func cancelButtonDidTap()
+    func resetButtonDidTap()
+    func saveButtonDidTap()
+    func colorChangeButtonDidTap()
+}
+
+extension CreationFormViewDelegate {
+    func colorChangeButtonDidTap() { }
+}
+
+final class CreationFormView: UIView {
+
+    // MARK: - IBOutlets
+    
+    @IBOutlet weak var firstLabel: UILabel!
+    @IBOutlet weak var secondLabel: UILabel!
+    @IBOutlet weak var thirdLabel: UILabel!
+    @IBOutlet weak var firstTextField: UITextField!
+    @IBOutlet weak var secondTextField: UITextField!
+    @IBOutlet weak var thirdTextField: UITextField!
+    @IBOutlet weak var colorSettingView: UIView!
+    @IBOutlet weak var colorSampleView: UIView!
+    
+    @IBOutlet weak var cancelButton: UIButton!
+    @IBOutlet weak var saveButton: UIButton!
+    @IBOutlet weak var resetButton: UIButton!
+    
+    // MARK: - Properties
+    
+    weak var delegate: CreationFormViewDelegate?
+    
+    var creationFormType: CreationFormType = .label {
+        didSet { configureThirdView() }
+    }
+    
+    var firstLabelName: String? {
+        get { return firstLabel.text }
+        set { firstLabel.text = newValue }
+    }
+    
+    var secondLabelName: String? {
+        get { return secondLabel.text }
+        set { secondLabel.text = newValue }
+    }
+    
+    var thirdLabelName: String? {
+        get { return thirdLabel.text }
+        set { thirdLabel.text = newValue }
+    }
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    // MARK: - IBActions
+    
+    @IBAction func cancelButtonDidTap(_ sender: UIButton) {
+        delegate?.cancelButtonDidTap()
+    }
+
+    @IBAction func resetButtonDidTap(_ sender: UIButton) {
+        delegate?.resetButtonDidTap()
+    }
+
+    @IBAction func saveButtonDidTap(_ sender: UIButton) {
+        delegate?.saveButtonDidTap()
+    }
+    
+    @IBAction func colorChangeButtonDidTap(_ sender: UIButton) {
+        delegate?.colorChangeButtonDidTap()
+    }
+    
+    // MARK: - Methods
+    
+    private func setup() {
+        let name = String(describing: CreationFormView.self)
+        guard let view = Bundle.main.loadNibNamed(name, owner: self, options: nil)?.first as? UIView  else { return }
+        self.layer.cornerRadius = 15
+        self.layer.masksToBounds = true
+        view.frame = self.bounds
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.addSubview(view)
+    }
+    
+    private func configureThirdView() {
+        if creationFormType == .milestone {
+            colorSettingView.isHidden = true
+        }
+    }
+    
+}
+
+extension CreationFormView {
+    
+    enum CreationFormType {
+        case label
+        case milestone
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.swift
@@ -23,41 +23,28 @@ final class CreationFormView: UIView {
 
     // MARK: - IBOutlets
     
-    @IBOutlet weak var firstLabel: UILabel!
-    @IBOutlet weak var secondLabel: UILabel!
-    @IBOutlet weak var thirdLabel: UILabel!
-    @IBOutlet weak var firstTextField: UITextField!
-    @IBOutlet weak var secondTextField: UITextField!
-    @IBOutlet weak var thirdTextField: UITextField!
+    @IBOutlet var titleLabels: [UILabel]! {
+        didSet { titleLabels.sort { $0.tag < $1.tag } }
+    }
+    
+    @IBOutlet var inputTextFields: [UITextField]! {
+        didSet { inputTextFields.sort { $0.tag < $1.tag } }
+    }
+    
     @IBOutlet weak var colorSettingView: UIView!
     @IBOutlet weak var colorSampleView: UIView!
-    
-    @IBOutlet weak var cancelButton: UIButton!
-    @IBOutlet weak var saveButton: UIButton!
-    @IBOutlet weak var resetButton: UIButton!
     
     // MARK: - Properties
     
     weak var delegate: CreationFormViewDelegate?
     
-    var creationFormType: CreationFormType = .label {
-        didSet { configureThirdView() }
-    }
+    var creationFormType: CreationFormType = .label
     
-    var firstLabelName: String? {
-        get { return firstLabel.text }
-        set { firstLabel.text = newValue }
-    }
+    var firstInputTextField: UITextField! { return inputTextFields[0] }
     
-    var secondLabelName: String? {
-        get { return secondLabel.text }
-        set { secondLabel.text = newValue }
-    }
+    var secondInputTextField: UITextField! { return inputTextFields[1] }
     
-    var thirdLabelName: String? {
-        get { return thirdLabel.text }
-        set { thirdLabel.text = newValue }
-    }
+    var thirdInputTextField: UITextField! { return inputTextFields[2] }
     
     // MARK: - Life Cycle
     
@@ -92,28 +79,25 @@ final class CreationFormView: UIView {
     // MARK: - Methods
     
     private func setup() {
-        let name = String(describing: CreationFormView.self)
-        guard let view = Bundle.main.loadNibNamed(name, owner: self, options: nil)?.first as? UIView  else { return }
         self.layer.cornerRadius = 15
         self.layer.masksToBounds = true
+        
+        let name = String(describing: CreationFormView.self)
+        guard let view = Bundle.main.loadNibNamed(name, owner: self, options: nil)?.first as? UIView  else { return }
         view.frame = self.bounds
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.addSubview(view)
     }
     
-    private func configureThirdView() {
-        if creationFormType == .milestone {
-            colorSettingView.isHidden = true
-        }
+    public func configureViewStyle() {
+        colorSettingView.isHidden = creationFormType == .milestone
+        secondInputTextField.placeholder = creationFormType == .milestone ? "yyyy-dd-mm(선택)" : ""
+        configureFormTitles()
     }
     
-}
-
-extension CreationFormView {
-    
-    enum CreationFormType {
-        case label
-        case milestone
+    private func configureFormTitles() {
+        let titles = creationFormType.formTitles
+        zip(titleLabels, titles).forEach { $0.text = $1 }
     }
     
 }

--- a/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.xib
+++ b/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.xib
@@ -9,17 +9,14 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CreationFormView" customModule="IssueTracker" customModuleProvider="target">
             <connections>
-                <outlet property="cancelButton" destination="0AK-3H-yl9" id="8yM-i1-lrG"/>
                 <outlet property="colorSampleView" destination="R7H-RA-wD2" id="jTp-BF-M64"/>
                 <outlet property="colorSettingView" destination="5Nn-eG-TQL" id="fb8-ym-QW4"/>
-                <outlet property="firstLabel" destination="5VW-Y5-vBx" id="yeq-I9-gdg"/>
-                <outlet property="firstTextField" destination="Hvl-Mk-eYQ" id="viC-6m-WEX"/>
-                <outlet property="resetButton" destination="gHj-j8-6a2" id="q9A-Dy-uzq"/>
-                <outlet property="saveButton" destination="Qww-jE-dZB" id="DHX-TM-W51"/>
-                <outlet property="secondLabel" destination="qzy-PY-HuA" id="Jds-NT-Lgj"/>
-                <outlet property="secondTextField" destination="bcd-n1-GWE" id="hmY-fm-SbD"/>
-                <outlet property="thirdLabel" destination="oWg-r2-bMG" id="OYL-5x-8oE"/>
-                <outlet property="thirdTextField" destination="xoJ-oO-cCe" id="0Vb-nx-5nk"/>
+                <outletCollection property="titleLabels" destination="5VW-Y5-vBx" collectionClass="NSMutableArray" id="Pdg-ho-t8W"/>
+                <outletCollection property="titleLabels" destination="qzy-PY-HuA" collectionClass="NSMutableArray" id="Xsi-EZ-of9"/>
+                <outletCollection property="titleLabels" destination="oWg-r2-bMG" collectionClass="NSMutableArray" id="IdH-hI-JwX"/>
+                <outletCollection property="inputTextFields" destination="Hvl-Mk-eYQ" collectionClass="NSMutableArray" id="a1a-fu-dK4"/>
+                <outletCollection property="inputTextFields" destination="bcd-n1-GWE" collectionClass="NSMutableArray" id="pcN-8Z-R5w"/>
+                <outletCollection property="inputTextFields" destination="xoJ-oO-cCe" collectionClass="NSMutableArray" id="rVc-qR-iJm"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -59,7 +56,7 @@
                                         </label>
                                         <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="230" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Hvl-Mk-eYQ">
                                             <rect key="frame" x="50" y="0.0" width="249" height="44"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
                                         </textField>
                                     </subviews>
@@ -87,7 +84,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="SAa-7o-cRz">
                                     <rect key="frame" x="0.0" y="0.0" width="299" height="44"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qzy-PY-HuA">
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qzy-PY-HuA" userLabel="설명">
                                             <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="30" id="fmc-08-vav"/>
@@ -96,9 +93,9 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="230" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bcd-n1-GWE">
+                                        <textField opaque="NO" tag="1" contentMode="scaleToFill" horizontalHuggingPriority="230" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bcd-n1-GWE">
                                             <rect key="frame" x="50" y="0.0" width="249" height="44"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
                                         </textField>
                                     </subviews>
@@ -126,7 +123,7 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Vde-VY-G6L">
                                     <rect key="frame" x="0.0" y="0.0" width="299" height="44"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWg-r2-bMG">
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색상" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWg-r2-bMG">
                                             <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="30" id="kme-6S-6RA"/>
@@ -135,9 +132,9 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xoJ-oO-cCe">
+                                        <textField opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xoJ-oO-cCe">
                                             <rect key="frame" x="50" y="0.0" width="87" height="44"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <textInputTraits key="textInputTraits"/>
                                         </textField>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Nn-eG-TQL">
@@ -215,10 +212,10 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qww-jE-dZB">
-                    <rect key="frame" x="255" y="310" width="64" height="38"/>
+                    <rect key="frame" x="247" y="310" width="72" height="38"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="64" id="YCu-Yk-a1V"/>
+                        <constraint firstAttribute="width" constant="72" id="YCu-Yk-a1V"/>
                         <constraint firstAttribute="height" constant="38" id="cej-UE-VfX"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="18"/>

--- a/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.xib
+++ b/iOS/IssueTracker/IssueTracker/View/CreationView/CreationFormView.xib
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CreationFormView" customModule="IssueTracker" customModuleProvider="target">
+            <connections>
+                <outlet property="cancelButton" destination="0AK-3H-yl9" id="8yM-i1-lrG"/>
+                <outlet property="colorSampleView" destination="R7H-RA-wD2" id="jTp-BF-M64"/>
+                <outlet property="colorSettingView" destination="5Nn-eG-TQL" id="fb8-ym-QW4"/>
+                <outlet property="firstLabel" destination="5VW-Y5-vBx" id="yeq-I9-gdg"/>
+                <outlet property="firstTextField" destination="Hvl-Mk-eYQ" id="viC-6m-WEX"/>
+                <outlet property="resetButton" destination="gHj-j8-6a2" id="q9A-Dy-uzq"/>
+                <outlet property="saveButton" destination="Qww-jE-dZB" id="DHX-TM-W51"/>
+                <outlet property="secondLabel" destination="qzy-PY-HuA" id="Jds-NT-Lgj"/>
+                <outlet property="secondTextField" destination="bcd-n1-GWE" id="hmY-fm-SbD"/>
+                <outlet property="thirdLabel" destination="oWg-r2-bMG" id="OYL-5x-8oE"/>
+                <outlet property="thirdTextField" destination="xoJ-oO-cCe" id="0Vb-nx-5nk"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="343" height="364"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0AK-3H-yl9">
+                    <rect key="frame" x="20" y="20" width="30" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="TUV-yt-wWO"/>
+                        <constraint firstAttribute="width" constant="30" id="nkF-eb-iJY"/>
+                    </constraints>
+                    <color key="tintColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <state key="normal" image="xmark" catalog="system"/>
+                    <connections>
+                        <action selector="cancelButtonDidTap:" destination="-1" eventType="touchUpInside" id="A1d-Iv-sqA"/>
+                    </connections>
+                </button>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rqr-0g-g2r">
+                    <rect key="frame" x="22" y="99" width="299" height="173"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Mn2-Cf-89H">
+                            <rect key="frame" x="0.0" y="0.0" width="299" height="45"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="6k3-FW-115">
+                                    <rect key="frame" x="0.0" y="0.0" width="299" height="44"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5VW-Y5-vBx">
+                                            <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="ql8-iJ-wrU"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="230" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Hvl-Mk-eYQ">
+                                            <rect key="frame" x="50" y="0.0" width="249" height="44"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="SK8-tw-oIG"/>
+                                    </constraints>
+                                </stackView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7b9-jR-mnh">
+                                    <rect key="frame" x="0.0" y="44" width="299" height="1"/>
+                                    <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="vHD-Ak-7cP"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="6k3-FW-115" secondAttribute="trailing" id="H0a-H4-MtY"/>
+                                <constraint firstItem="7b9-jR-mnh" firstAttribute="width" secondItem="Mn2-Cf-89H" secondAttribute="width" id="Vdo-hp-Zsi"/>
+                                <constraint firstItem="6k3-FW-115" firstAttribute="leading" secondItem="Mn2-Cf-89H" secondAttribute="leading" id="w7T-i7-Deg"/>
+                            </constraints>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="JJd-b6-hGx">
+                            <rect key="frame" x="0.0" y="64" width="299" height="45"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="SAa-7o-cRz">
+                                    <rect key="frame" x="0.0" y="0.0" width="299" height="44"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qzy-PY-HuA">
+                                            <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="fmc-08-vav"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="230" horizontalCompressionResistancePriority="740" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bcd-n1-GWE">
+                                            <rect key="frame" x="50" y="0.0" width="249" height="44"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="0Bn-Ud-JAE"/>
+                                    </constraints>
+                                </stackView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k2K-sU-w8u">
+                                    <rect key="frame" x="0.0" y="44" width="299" height="1"/>
+                                    <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="cz1-D5-xso"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="SAa-7o-cRz" firstAttribute="leading" secondItem="JJd-b6-hGx" secondAttribute="leading" id="08f-qJ-MD1"/>
+                                <constraint firstItem="k2K-sU-w8u" firstAttribute="width" secondItem="JJd-b6-hGx" secondAttribute="width" id="BNI-Y0-GaO"/>
+                                <constraint firstAttribute="trailing" secondItem="SAa-7o-cRz" secondAttribute="trailing" id="y6C-9B-M7a"/>
+                            </constraints>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="iRz-eu-Awv">
+                            <rect key="frame" x="0.0" y="128" width="299" height="45"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Vde-VY-G6L">
+                                    <rect key="frame" x="0.0" y="0.0" width="299" height="44"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="제목" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oWg-r2-bMG">
+                                            <rect key="frame" x="0.0" y="0.0" width="30" height="44"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="kme-6S-6RA"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xoJ-oO-cCe">
+                                            <rect key="frame" x="50" y="0.0" width="87" height="44"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits"/>
+                                        </textField>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Nn-eG-TQL">
+                                            <rect key="frame" x="157" y="0.0" width="142" height="44"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R7H-RA-wD2">
+                                                    <rect key="frame" x="8" y="7" width="74" height="30"/>
+                                                    <color key="backgroundColor" systemColor="systemOrangeColor" red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="30" id="cO2-xf-YRb"/>
+                                                        <constraint firstAttribute="width" constant="74" id="v3J-Mb-eby"/>
+                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                            <integer key="value" value="12"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qBt-JO-uGd">
+                                                    <rect key="frame" x="109" y="5.5" width="33" height="33"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="33" id="FdL-k6-6Sj"/>
+                                                        <constraint firstAttribute="width" secondItem="qBt-JO-uGd" secondAttribute="height" multiplier="1:1" id="eTy-Tu-GnJ"/>
+                                                    </constraints>
+                                                    <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <state key="normal" image="repeat" catalog="system"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                            <real key="value" value="16.5"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                    <connections>
+                                                        <action selector="colorChangeButtonDidTap:" destination="-1" eventType="touchUpInside" id="JDh-jG-HpS"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            <constraints>
+                                                <constraint firstItem="qBt-JO-uGd" firstAttribute="centerY" secondItem="5Nn-eG-TQL" secondAttribute="centerY" id="LMZ-dw-Fbq"/>
+                                                <constraint firstItem="qBt-JO-uGd" firstAttribute="leading" secondItem="R7H-RA-wD2" secondAttribute="trailing" constant="27" id="Ney-40-IHa"/>
+                                                <constraint firstAttribute="trailing" secondItem="qBt-JO-uGd" secondAttribute="trailing" id="Wjb-EJ-OMa"/>
+                                                <constraint firstItem="R7H-RA-wD2" firstAttribute="leading" secondItem="5Nn-eG-TQL" secondAttribute="leading" constant="8" id="c5m-vD-cBF"/>
+                                                <constraint firstItem="R7H-RA-wD2" firstAttribute="centerY" secondItem="5Nn-eG-TQL" secondAttribute="centerY" id="zXe-DL-O9s"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="OHl-mF-09j"/>
+                                    </constraints>
+                                </stackView>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="teX-Js-taR">
+                                    <rect key="frame" x="0.0" y="44" width="299" height="1"/>
+                                    <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="1" id="IPf-l3-Rx8"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="Vde-VY-G6L" secondAttribute="trailing" id="8X5-L0-p7s"/>
+                                <constraint firstItem="Vde-VY-G6L" firstAttribute="leading" secondItem="iRz-eu-Awv" secondAttribute="leading" id="U02-Hl-t9G"/>
+                                <constraint firstItem="teX-Js-taR" firstAttribute="width" secondItem="iRz-eu-Awv" secondAttribute="width" id="ls1-Dv-qkZ"/>
+                            </constraints>
+                        </stackView>
+                    </subviews>
+                </stackView>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gHj-j8-6a2">
+                    <rect key="frame" x="24" y="314.5" width="37" height="29"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <color key="tintColor" red="0.4392156862745098" green="0.4392156862745098" blue="0.4392156862745098" alpha="1" colorSpace="calibratedRGB"/>
+                    <state key="normal" title="초기화"/>
+                    <connections>
+                        <action selector="resetButtonDidTap:" destination="-1" eventType="touchUpInside" id="hly-eD-AKb"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qww-jE-dZB">
+                    <rect key="frame" x="255" y="310" width="64" height="38"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="64" id="YCu-Yk-a1V"/>
+                        <constraint firstAttribute="height" constant="38" id="cej-UE-VfX"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <state key="normal" title="저장"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="10"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="saveButtonDidTap:" destination="-1" eventType="touchUpInside" id="Wwb-1n-x3E"/>
+                    </connections>
+                </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rTy-dI-EMG">
+                    <rect key="frame" x="0.0" y="66" width="343" height="1"/>
+                    <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="zqs-A6-wn3"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="0AK-3H-yl9" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="2Br-sy-eHy"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="Qww-jE-dZB" secondAttribute="bottom" constant="16" id="GuC-Dz-umf"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rqr-0g-g2r" secondAttribute="trailing" constant="22" id="HPP-50-M91"/>
+                <constraint firstItem="rqr-0g-g2r" firstAttribute="top" secondItem="rTy-dI-EMG" secondAttribute="bottom" constant="32" id="LJE-3j-yRL"/>
+                <constraint firstItem="rTy-dI-EMG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="N4G-1a-u2N"/>
+                <constraint firstItem="Qww-jE-dZB" firstAttribute="top" secondItem="rqr-0g-g2r" secondAttribute="bottom" constant="38" id="NPg-pG-biq"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Qww-jE-dZB" secondAttribute="trailing" constant="24" id="RQC-oy-njy"/>
+                <constraint firstAttribute="trailing" secondItem="rTy-dI-EMG" secondAttribute="trailing" id="abq-BU-z8p"/>
+                <constraint firstItem="0AK-3H-yl9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="c3K-bk-QuT"/>
+                <constraint firstItem="rTy-dI-EMG" firstAttribute="top" secondItem="0AK-3H-yl9" secondAttribute="bottom" constant="16" id="f18-SQ-gJn"/>
+                <constraint firstItem="gHj-j8-6a2" firstAttribute="centerY" secondItem="Qww-jE-dZB" secondAttribute="centerY" id="hQ5-h0-Nes"/>
+                <constraint firstItem="rqr-0g-g2r" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="22" id="hmm-xl-0N8"/>
+                <constraint firstItem="gHj-j8-6a2" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="24" id="w04-To-tNN"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="152.89855072463769" y="-56.25"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="repeat" catalog="system" width="128" height="99"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
+    </resources>
+</document>


### PR DESCRIPTION
## :white_check_mark: 작업 내용
- [x] `CreationFormView` 구현

## :hammer: 변경로직
- 초기구현

## :camera_flash: 스크린샷 (Optional)
<img width="253" alt="스크린샷 2020-10-30 오전 10 20 47" src="https://user-images.githubusercontent.com/15014017/97649017-95c58380-1a99-11eb-9441-0ae19cfaa2fd.png">

## :lock: 관련 이슈(닫을 이슈)
- close #3 
