### PR TITLE
[iOS] 이슈 목록 하단 메뉴뷰, Cell Checkmark 이미지 작성 및 적용

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		970CAD57254A73B60076691E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 970CAD55254A73B60076691E /* LaunchScreen.storyboard */; };
 		970CAD62254A73B60076691E /* IssueTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970CAD61254A73B60076691E /* IssueTrackerTests.swift */; };
 		9724708A25501AF800285073 /* MilestoneDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9724708925501AF800285073 /* MilestoneDetailViewController.swift */; };
+		974574FA2552DDA8007E1F04 /* BottomMenuView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 974574F92552DDA8007E1F04 /* BottomMenuView.xib */; };
+		974574FC2552DDB3007E1F04 /* BottomMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974574FB2552DDB3007E1F04 /* BottomMenuView.swift */; };
+		974574FE2552DED7007E1F04 /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 974574FD2552DED7007E1F04 /* UICollectionView+.swift */; };
 		9763DFF0254B361200BCBD6A /* CreationFormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9763DFEF254B361200BCBD6A /* CreationFormType.swift */; };
 		97664C66254A83CB005B98A7 /* CreationFormView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 97664C65254A83CB005B98A7 /* CreationFormView.xib */; };
 		97664C68254A91CA005B98A7 /* CreationFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97664C67254A91CA005B98A7 /* CreationFormView.swift */; };
@@ -93,6 +96,9 @@
 		970CAD61254A73B60076691E /* IssueTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTrackerTests.swift; sourceTree = "<group>"; };
 		970CAD63254A73B60076691E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9724708925501AF800285073 /* MilestoneDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneDetailViewController.swift; sourceTree = "<group>"; };
+		974574F92552DDA8007E1F04 /* BottomMenuView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BottomMenuView.xib; sourceTree = "<group>"; };
+		974574FB2552DDB3007E1F04 /* BottomMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomMenuView.swift; sourceTree = "<group>"; };
+		974574FD2552DED7007E1F04 /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		9763DFEF254B361200BCBD6A /* CreationFormType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFormType.swift; sourceTree = "<group>"; };
 		97664C65254A83CB005B98A7 /* CreationFormView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreationFormView.xib; sourceTree = "<group>"; };
 		97664C67254A91CA005B98A7 /* CreationFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreationFormView.swift; sourceTree = "<group>"; };
@@ -147,6 +153,7 @@
 				7C13044725502AE2003AE6A1 /* UIColor+.swift */,
 				97DAB2CA255034DE002C3E21 /* String+.swift */,
 				9793CFB325516101006235B1 /* UIView+.swift */,
+				974574FD2552DED7007E1F04 /* UICollectionView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -164,6 +171,8 @@
 			isa = PBXGroup;
 			children = (
 				7C13044B25511DC0003AE6A1 /* IssueMainViewController.swift */,
+				974574FB2552DDB3007E1F04 /* BottomMenuView.swift */,
+				974574F92552DDA8007E1F04 /* BottomMenuView.xib */,
 				7C13044D25511F9A003AE6A1 /* IssueCollectionViewCell.swift */,
 				7C13044F25512AB5003AE6A1 /* SwipeableCollectionViewCell.swift */,
 				7C130451255132E7003AE6A1 /* IssueContentView.xib */,
@@ -382,6 +391,7 @@
 			files = (
 				970CAD57254A73B60076691E /* LaunchScreen.storyboard in Resources */,
 				7C2A9052254BA60500AFC5C4 /* Issue.storyboard in Resources */,
+				974574FA2552DDA8007E1F04 /* BottomMenuView.xib in Resources */,
 				7C2A9056254BA61F00AFC5C4 /* Milestone.storyboard in Resources */,
 				97664C66254A83CB005B98A7 /* CreationFormView.xib in Resources */,
 				970CAD54254A73B60076691E /* Assets.xcassets in Resources */,
@@ -473,7 +483,9 @@
 			files = (
 				9763DFF0254B361200BCBD6A /* CreationFormType.swift in Sources */,
 				7C130443254FEEB0003AE6A1 /* LabelAddViewController.swift in Sources */,
+				974574FC2552DDB3007E1F04 /* BottomMenuView.swift in Sources */,
 				970CAD4F254A73B50076691E /* ViewController.swift in Sources */,
+				974574FE2552DED7007E1F04 /* UICollectionView+.swift in Sources */,
 				97A1930F255270FD00A4B9D7 /* CircleButton.swift in Sources */,
 				977B9C54254FA7A500D00B28 /* MilestoneMainViewController.swift in Sources */,
 				7C13043E254FC989003AE6A1 /* LabelCollectionViewCell.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Extensions/UICollectionView+.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/UICollectionView+.swift
@@ -1,0 +1,9 @@
+//
+//  UICollectionView+.swift
+//  IssueTracker
+//
+//  Created by 김근수 on 2020/11/04.
+//  Copyright © 2020 김근수. All rights reserved.
+//
+
+import Foundation

--- a/iOS/IssueTracker/IssueTracker/Extensions/UICollectionView+.swift
+++ b/iOS/IssueTracker/IssueTracker/Extensions/UICollectionView+.swift
@@ -6,4 +6,24 @@
 //  Copyright © 2020 김근수. All rights reserved.
 //
 
-import Foundation
+import UIKit
+
+extension UICollectionView {
+    
+    public func selectAll() {
+        for section in 0..<self.numberOfSections {
+            for item in 0..<self.numberOfItems(inSection: section) {
+                self.selectItem(at: IndexPath(item: item, section: section), animated: false, scrollPosition: [])
+            }
+        }
+    }
+    
+    public func deselectAll() {
+        for section in 0..<self.numberOfSections {
+            for item in 0..<self.numberOfItems(inSection: section) {
+                self.deselectItem(at: IndexPath(item: item, section: section), animated: false)
+            }
+        }
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/Issue/BottomMenuView.swift
+++ b/iOS/IssueTracker/IssueTracker/Issue/BottomMenuView.swift
@@ -1,0 +1,35 @@
+//
+//  BottomMenuView.swift
+//  IssueTracker
+//
+//  Created by 김근수 on 2020/11/04.
+//  Copyright © 2020 김근수. All rights reserved.
+//
+
+import UIKit
+
+class BottomMenuView: UIView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    private func setup() {
+        let name = String(describing: BottomMenuView.self)
+        guard let view = Bundle.main.loadNibNamed(name, owner: self, options: nil)?.first as? UIView  else { return }
+        view.frame = self.bounds
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.addSubview(view)
+    }
+    
+    public func toggle(with isEditing: Bool) {
+        guard let superView = self.superview else { return }
+        self.frame.origin.y = isEditing ? superView.frame.height - frame.height : superView.frame.height
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Issue/BottomMenuView.xib
+++ b/iOS/IssueTracker/IssueTracker/Issue/BottomMenuView.xib
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BottomMenuView" customModule="IssueTracker" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="80"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9hY-Ws-dfe">
+                    <rect key="frame" x="312" y="16" width="86" height="30"/>
+                    <state key="normal" title="선택 이슈 닫기"/>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="0.97647058823529409" green="0.97647058823529409" blue="0.97647058823529409" alpha="1" colorSpace="calibratedRGB"/>
+            <constraints>
+                <constraint firstItem="9hY-Ws-dfe" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="16" id="3HR-ZH-mSu"/>
+                <constraint firstAttribute="trailing" secondItem="9hY-Ws-dfe" secondAttribute="trailing" constant="16" id="khd-gw-Osz"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="-31.159420289855074" y="38.839285714285715"/>
+        </view>
+    </objects>
+</document>

--- a/iOS/IssueTracker/IssueTracker/Issue/IssueCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Issue/IssueCollectionViewCell.swift
@@ -10,7 +10,25 @@ import UIKit
 
 final class IssueCollectionViewCell: SwipeableCollectionViewCell {
     
+    public static let identifier = String(describing: IssueCollectionViewCell.self)
+    
     var issueContentView = IssueContentView()
+    
+    var isEditing: Bool = false {
+        didSet {
+            UIView.animate(withDuration: 0.3) {
+                self.issueContentView.checkView.isHidden = !self.isEditing
+            }
+            scrollView.isScrollEnabled = !isEditing
+        }
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            issueContentView.checkImageView.image
+            = isSelected ? UIImage(systemName: "checkmark.circle.fill") : UIImage(systemName: "circle")
+        }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -22,7 +40,12 @@ final class IssueCollectionViewCell: SwipeableCollectionViewCell {
         setupSubviews()
     }
     
+    func configure(isEditing: Bool) {
+        self.isEditing = isEditing
+    }
+    
     private func setupSubviews() {
+        
         visibleContainerView.backgroundColor = .white
         
         visibleContainerView.addSubview(issueContentView)

--- a/iOS/IssueTracker/IssueTracker/Issue/IssueContentView.swift
+++ b/iOS/IssueTracker/IssueTracker/Issue/IssueContentView.swift
@@ -14,6 +14,8 @@ class IssueContentView: UIView {
     @IBOutlet weak var contentLabel: UILabel!
     @IBOutlet weak var milestoneLabel: BadgeLabel!
     @IBOutlet weak var issueLabelLabel: BadgeLabel!
+    @IBOutlet weak var checkView: UIView!
+    @IBOutlet weak var checkImageView: UIImageView!
     
     // MARK: - Life Cycle
     

--- a/iOS/IssueTracker/IssueTracker/Issue/IssueContentView.xib
+++ b/iOS/IssueTracker/IssueTracker/Issue/IssueContentView.xib
@@ -9,6 +9,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueContentView" customModule="IssueTracker" customModuleProvider="target">
             <connections>
+                <outlet property="checkImageView" destination="ZL4-8L-Tma" id="xDl-m7-Tct"/>
+                <outlet property="checkView" destination="0r8-xG-Tl7" id="YZ2-pZ-c5t"/>
                 <outlet property="contentLabel" destination="vmH-HR-wJH" id="npm-1G-kBu"/>
                 <outlet property="issueLabelLabel" destination="RxR-d1-neV" id="8rS-an-NTs"/>
                 <outlet property="milestoneLabel" destination="soW-h2-QFf" id="fzl-pI-szk"/>
@@ -20,11 +22,29 @@
             <rect key="frame" x="0.0" y="0.0" width="409" height="88"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="yAq-8A-FCP">
-                    <rect key="frame" x="16" y="10" width="377" height="68"/>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="yAq-8A-FCP">
+                    <rect key="frame" x="16" y="10" width="421" height="68"/>
                     <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0r8-xG-Tl7">
+                            <rect key="frame" x="0.0" y="0.0" width="36" height="68"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ZL4-8L-Tma">
+                                    <rect key="frame" x="0.0" y="24.5" width="20" height="19"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="20" id="Cnu-y8-uWH"/>
+                                        <constraint firstAttribute="width" constant="20" id="pCk-j6-wXL"/>
+                                    </constraints>
+                                </imageView>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <constraints>
+                                <constraint firstItem="ZL4-8L-Tma" firstAttribute="leading" secondItem="0r8-xG-Tl7" secondAttribute="leading" id="k0y-xD-gwd"/>
+                                <constraint firstItem="ZL4-8L-Tma" firstAttribute="centerY" secondItem="0r8-xG-Tl7" secondAttribute="centerY" id="kDu-GC-fml"/>
+                                <constraint firstAttribute="trailing" secondItem="ZL4-8L-Tma" secondAttribute="trailing" constant="16" id="siR-e5-Buc"/>
+                            </constraints>
+                        </view>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="2Tq-Aj-zZt">
-                            <rect key="frame" x="0.0" y="0.0" width="308" height="62.5"/>
+                            <rect key="frame" x="41" y="0.0" width="308" height="62.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5AW-fx-92D">
                                     <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
@@ -40,11 +60,11 @@
                                 </label>
                             </subviews>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="749" axis="vertical" alignment="bottom" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="GDt-QL-GV8">
-                            <rect key="frame" x="308" y="0.0" width="69" height="41"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="GDt-QL-GV8">
+                            <rect key="frame" x="354" y="0.0" width="67" height="49"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="스프린트2" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soW-h2-QFf" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                    <rect key="frame" x="12" y="0.0" width="57" height="17"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="67" height="21"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -58,7 +78,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxR-d1-neV" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                    <rect key="frame" x="33.5" y="24" width="35.5" height="17"/>
+                                    <rect key="frame" x="21.5" y="28" width="45.5" height="21"/>
                                     <color key="backgroundColor" red="0.74509803919999995" green="0.85882352939999995" blue="0.99215686270000003" alpha="1" colorSpace="calibratedRGB"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <nil key="textColor"/>
@@ -76,7 +96,7 @@
                         </stackView>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="GDt-QL-GV8" firstAttribute="width" secondItem="yAq-8A-FCP" secondAttribute="width" multiplier="0.183036" id="dy6-S1-zog"/>
+                        <constraint firstItem="0r8-xG-Tl7" firstAttribute="height" secondItem="yAq-8A-FCP" secondAttribute="height" id="jVW-2t-7rP"/>
                     </constraints>
                 </stackView>
             </subviews>
@@ -85,11 +105,15 @@
                 <constraint firstItem="yAq-8A-FCP" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="AwV-JJ-7HA"/>
                 <constraint firstItem="yAq-8A-FCP" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="10" id="MEj-20-O11"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="yAq-8A-FCP" secondAttribute="bottom" constant="10" id="UyV-XS-avu"/>
-                <constraint firstAttribute="trailing" secondItem="yAq-8A-FCP" secondAttribute="trailing" constant="16" id="oad-lD-H3d"/>
+                <constraint firstItem="2Tq-Aj-zZt" firstAttribute="width" secondItem="vUN-kp-3ea" secondAttribute="width" multiplier="0.753056" id="dFg-WN-Biu"/>
+                <constraint firstAttribute="trailing" secondItem="yAq-8A-FCP" secondAttribute="trailing" priority="250" constant="16" id="oad-lD-H3d"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="128.2608695652174" y="-91.071428571428569"/>
         </view>
     </objects>
+    <resources>
+        <image name="circle" catalog="system" width="128" height="121"/>
+    </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Issue/SwipeableCollectionViewCell.swift
+++ b/iOS/IssueTracker/IssueTracker/Issue/SwipeableCollectionViewCell.swift
@@ -18,7 +18,7 @@ class SwipeableCollectionViewCell: UICollectionViewCell {
     
     // MARK: Properties
     
-    private let scrollView: UIScrollView = {
+    let scrollView: UIScrollView = {
         let scrollView = UIScrollView(frame: .zero)
         scrollView.isPagingEnabled = true
         scrollView.showsVerticalScrollIndicator = false

--- a/iOS/IssueTracker/IssueTracker/Storyboards/Issue.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Storyboards/Issue.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9aI-ki-UYl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="XAM-Af-gGY">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -305,7 +305,7 @@
                     <tabBarItem key="tabBarItem" title="이슈" image="1.circle.fill" catalog="system" id="w18-gd-ICJ"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="9jn-nu-mX1">
-                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/iOS/IssueTracker/Podfile.lock
+++ b/iOS/IssueTracker/Podfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  trunk:
     - SwiftLint
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
## :white_check_mark: 작업 내용
- [x] 이슈 하단 메뉴뷰 구성
- [x] IssueContentView 에 Checkmark ImageView 추가
- [x] Editmode 시 toggle 로직 추가

## :hammer: 변경로직
- 하단 메뉴 초기 구현 및 checkmark image 추가

## :camera_flash: 스크린샷 (Optional)
  <img width="300" alt="스크린샷 2020-11-04 오후 10 18 31" src="https://user-images.githubusercontent.com/15014017/98116655-edc21700-1eeb-11eb-8d80-29a896e79126.png">

## :lock: 관련 이슈(닫을 이슈)
- close #36 
