### PR TITLE
[iOS] 이슈 추가 뷰 마크다운 랜더

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Issue/Add/ContentTextView.swift
+++ b/iOS/IssueTracker/IssueTracker/Issue/Add/ContentTextView.swift
@@ -14,7 +14,7 @@ protocol InsertPhotoDelegate: class {
 
 final class ContentTextView: UITextView {
     
-    private var placeholderText = "코멘트는 여기에 작성하세요"
+    var placeholderText = "코멘트는 여기에 작성하세요"
     weak var photoDelegate: InsertPhotoDelegate?
     
     override func awakeFromNib() {
@@ -33,6 +33,7 @@ final class ContentTextView: UITextView {
                                    withSender sender: Any?) -> Bool {
         return action == #selector(cut(_:))
             || action == #selector(copy(_:))
+            || action == #selector(paste(_:))
             || action == #selector(insertPhotoDidTap)
     }
     

--- a/iOS/IssueTracker/IssueTracker/Storyboards/Issue.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Storyboards/Issue.storyboard
@@ -236,15 +236,15 @@
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rJh-B5-lac">
                                                                             <rect key="frame" x="0.0" y="0.0" width="44" height="30.5"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="height" constant="30.5" id="XD1-ZG-tIU"/>
-                                                                            </constraints>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l5x-ri-vkA">
                                                                             <rect key="frame" x="0.0" y="30.5" width="44" height="19.5"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="19.5" id="jMe-v3-0YB"/>
+                                                                            </constraints>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                                             <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                             <nil key="highlightedColor"/>
@@ -253,8 +253,8 @@
                                                                 </stackView>
                                                             </subviews>
                                                         </stackView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 이슈 댓글 " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Fa-oW-2Qo">
-                                                            <rect key="frame" x="0.0" y="65" width="357.5" height="32"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Fa-oW-2Qo">
+                                                            <rect key="frame" x="0.0" y="65" width="36.5" height="32"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -338,7 +338,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pk3-bN-Dxo" customClass="BadgeLabel" customModule="IssueTracker" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="83.5" width="45.5" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="83.5" width="49.5" height="20.5"/>
                                                     <color key="backgroundColor" red="0.93333333333333335" green="0.97254901960784312" blue="0.94117647058823528" alpha="0.84705882352941175" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" priority="250" constant="20.5" id="o1N-CD-FiK"/>
@@ -761,7 +761,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="els-zj-Nw7">
                                         <rect key="frame" x="0.0" y="61" width="366" height="604.5"/>
                                         <subviews>
-                                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="rSa-DU-JH1">
+                                            <segmentedControl opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="rSa-DU-JH1">
                                                 <rect key="frame" x="0.0" y="0.0" width="366" height="33"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="32" id="vag-9f-dL2"/>
@@ -781,6 +781,10 @@
                                                     <outlet property="delegate" destination="JuO-2g-Psz" id="InS-2N-fD7"/>
                                                 </connections>
                                             </textView>
+                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yxB-aB-RGS" customClass="MarkdownView" customModule="IssueTracker" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="604.5" width="366" height="0.0"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                            </view>
                                         </subviews>
                                     </stackView>
                                 </subviews>

--- a/iOS/IssueTracker/Podfile
+++ b/iOS/IssueTracker/Podfile
@@ -8,6 +8,7 @@ target 'IssueTracker' do
   # Swift Lint
   pod 'SwiftLint'
   pod 'Alamofire'
+  pod 'MarkdownView'
 
   target 'IssueTrackerTests' do
     inherit! :search_paths

--- a/iOS/IssueTracker/Podfile.lock
+++ b/iOS/IssueTracker/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
   - Alamofire (5.4.0)
+  - MarkdownView (1.7.1)
   - SwiftLint (0.40.3)
 
 DEPENDENCIES:
   - Alamofire
+  - MarkdownView
   - SwiftLint
 
 SPEC REPOS:
   https://cdn.cocoapods.org/:
     - Alamofire
+    - MarkdownView
     - SwiftLint
 
 SPEC CHECKSUMS:
   Alamofire: 3b6a534a3df22db367e4dedeeca73d1ddfcf0e2f
+  MarkdownView: cf30a97ab39b2bce04406adce541972c882363bd
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
-PODFILE CHECKSUM: 4a703d30cdc959b325a1426e13e96e9d862b1903
+PODFILE CHECKSUM: ebed456bae41fd0ad131bfc377737b9c8d4247ae
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
## :white_check_mark: 작업 내용
이슈 추가 뷰 마크다운 랜더

## :hammer: 변경로직
 - pod install - pod 'MarkdownView'라이브러리
 - Markdown랜더한 것을 넣어줄 뷰 추가
 - Markdown뷰를 텍스트 뷰 크기에 맞춤
-  UI를 StackView로 구성해서 textView를 isHidden하면 UI가 깨진다. 그래서 textView를 Alpha값으로 주어 숨김

## :camera_flash: 스크린샷
![image](https://user-images.githubusercontent.com/26567846/98707247-29b11c80-23c3-11eb-9b61-c42e5137a0fd.png)

## :lock: 관련 이슈(닫을 이슈)
- close #74 
